### PR TITLE
COFF Format Support

### DIFF
--- a/win32/dfl/makecoff.bat
+++ b/win32/dfl/makecoff.bat
@@ -1,0 +1,167 @@
+@rem   Make DFL.
+@rem   http://www.dprogramming.com/dfl.php
+@rem   Modified for 64-bit and COFF object format
+
+@rem   Requires DMD and DMC's libs
+@rem   Free downloads from http://www.digitalmars.com/d/dcompiler.html and http://www.digitalmars.com/download/freecompiler.html
+
+@rem   If you prefer to make DFL64 or 32-bit COFF library format,
+@rem   This requies DMD tools _and_ MSVC build tools (tested with MSVC 2013 Community Ed.),
+
+@echo off
+@cls
+
+@rem   you can change the default object model here
+set MODEL=32mscoff
+if not "%1"=="" set MODEL=%1
+
+
+@rem   You have to change these paths to your machine environment.
+@rem   "Visual Studio 12.0" means MSVC 2013.
+@rem   sc.ini in dmd2/windows/bin will help you.
+
+@rem   path to linker
+@rem set LIBCMD="C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\lib.exe"
+set LIBCMD="C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\x86_amd64\lib.exe"
+
+@rem   path to mspdb120.dll, mspdb110.dll, mspdb100.dll, and so on
+@rem   IMPORTANT: The MSVC build tools may depends on dlls which are separated into x86/x64 on installation,
+@rem              then you MUST choose a path to the suitable version.
+@rem set VCCOMMON="C:\Program Files (x86)\Microsoft Visual Studio 10.0\Common7\IDE"
+@rem set VCCOMMON=C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\amd64
+set VCCOMMON=C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin
+
+@rem   path to Windows SDK static libs (ex.gdi32.lib)
+@if "%MODEL%"=="64" (
+  @rem set WINSDKLIB="C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\Lib\x64"
+  set WINSDKLIB="C:\Program Files (x86)\Windows Kits\8.1\Lib\winv6.3\um\x64"
+) else (
+  @rem set WINSDKLIB="C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A"
+  set WINSDKLIB="C:\Program Files (x86)\Windows Kits\8.1\Lib\winv6.3\um\x86"
+)
+
+@set PATH=%VCCOMMON%;%PATH%
+
+@rem   Either set the environment variables dmd_path and dmc_path
+@rem   or fix the paths below.
+
+if not "%dmd_path%" == "" goto dmd_set
+set dmd_path=c:\dmd
+:dmd_set
+set dmd_path_windows=%dmd_path%\windows
+if not exist %dmd_path_windows%\bin\dmd.exe set dmd_path_windows=%dmd_path%
+set _stdcwindowsd=
+set _stdcwindowsobj=
+if not "%dlib%" == "Tango" goto dfl_not_tango_files
+set _stdcwindowsd=internal/_stdcwindows.d
+set _stdcwindowsobj=_stdcwindows.obj
+:dfl_not_tango_files
+
+set dfl_files=package.d all.d base.d application.d internal/dlib.d internal/clib.d internal/utf.d internal/com.d control.d clippingform.d form.d registry.d drawing.d menu.d notifyicon.d commondialog.d filedialog.d folderdialog.d panel.d textbox.d richtextbox.d picturebox.d listbox.d groupbox.d splitter.d usercontrol.d button.d label.d collections.d internal/winapi.d internal/wincom.d event.d socket.d timer.d environment.d messagebox.d tooltip.d combobox.d treeview.d tabcontrol.d colordialog.d listview.d data.d clipboard.d fontdialog.d progressbar.d resources.d statusbar.d imagelist.d toolbar.d %_stdcwindowsd%
+
+set dfl_objs=package.obj all.obj base.obj application.obj dlib.obj clib.obj utf.obj com.obj control.obj clippingform.obj form.obj registry.obj drawing.obj menu.obj notifyicon.obj commondialog.obj filedialog.obj folderdialog.obj panel.obj textbox.obj richtextbox.obj picturebox.obj listbox.obj groupbox.obj splitter.obj usercontrol.obj button.obj label.obj collections.obj winapi.obj wincom.obj event.obj socket.obj timer.obj environment.obj messagebox.obj tooltip.obj combobox.obj treeview.obj tabcontrol.obj colordialog.obj listview.obj data.obj clipboard.obj fontdialog.obj progressbar.obj resources.obj statusbar.obj imagelist.obj toolbar.obj %_stdcwindowsobj%
+
+@rem   Also update link pragmas for build.
+@rem set dfl_libs_dfl=user32_dfl.lib shell32_dfl.lib olepro32_dfl.lib
+set dfl_libs_dfl=user32.lib shell32.lib oleaut32.lib
+set dfl_libs=gdi32.lib comctl32.lib advapi32.lib comdlg32.lib ole32.lib uuid.lib ws2_32.lib %dfl_libs_dfl%
+
+@rem   -version=NO_DRAG_DROP -version=NO_MDI
+@rem   -debug=SHOW_MESSAGE_INFO -debug=MESSAGE_PAUSE
+@rem set dfl_flags=%dfl_flags% -debug=SHOW_MESSAGENFO
+set _dfl_flags=%dfl_flags% -wi
+
+if not "%dfl_debug_flags%" == "" goto dfl_debug_flags_set
+	set dfl_debug_flags=-debug -version=DFL_UNICODE
+:dfl_debug_flags_set
+
+if not "%dfl_release_flags%" == "" goto dfl_release_flags_set
+@rem	if not "%dlib%" == "Tango" goto dfl_not_release_tango
+@rem	echo Due to a bug in DMD, release mode dfl lib will not include -inline; use environment variable dfl_release_flags to override.
+@rem	set dfl_release_flags=-O -release
+@rem	goto dfl_release_flags_set
+@rem	:dfl_not_release_tango
+	set dfl_release_flags=-O -release -version=DFL_UNICODE
+:dfl_release_flags_set
+
+
+@echo on
+
+
+@if "%dfl_ddoc%" == "" goto after_dfl_ddoc
+@echo.
+@echo Generating ddoc documentation...
+
+%dmd_path_windows%\bin\dmd %_dfl_flags% %dfl_options% -c -o- -Dddoc %dfl_files%
+@if errorlevel 1 goto oops
+
+@if "%dfl_ddoc%" == "only" goto done
+@if not "%dfl_ddoc_only%" == "" goto done
+:after_dfl_ddoc
+
+
+@rem   @echo.
+@rem   @echo Generating headers...
+@rem   @del *.di
+@rem   %dmd_path_windows%\bin\dmd -H -o- -c -I.. %_dfl_flags% %dfl_options% %dfl_files%
+@rem   @if errorlevel 1 goto oops
+
+
+@echo.
+@echo Compiling debug DFL...
+
+%dmd_path_windows%\bin\dmd -m%MODEL% -c %dfl_debug_flags% %_dfl_flags% %dfl_options% -I.. %dfl_files%
+@if errorlevel 1 goto oops
+
+@echo.
+@echo Making debug lib...
+
+%LIBCMD% /out:dfl_debug.lib /libpath:%WINSDKLIB% %dfl_libs% %dfl_objs%
+@if errorlevel 1 goto oops
+@echo We may ignore warnings of 4006,4221...
+
+
+@echo.
+@echo Compiling release DFL...
+
+%dmd_path_windows%\bin\dmd -m%MODEL% -c %dfl_release_flags% %_dfl_flags% %dfl_options% -I.. %dfl_files%
+@if errorlevel 1 goto oops
+
+@echo.
+@echo Making release lib...
+
+%LIBCMD% /out:dfl.lib /libpath:%WINSDKLIB% %dfl_libs% %dfl_objs%
+@if errorlevel 1 goto oops
+@echo We may ignore warnings of 4006,4221...
+
+@echo.
+@rem this may probably be Win32 only...
+@rem   @echo Making build lib...
+
+@rem   %LIBCMD% /out:dfl_build.lib
+@rem   @if errorlevel 1 goto oops
+
+
+@rem   This file is used by dfl.exe
+@echo dlib=%dlib%>dflcompile.info
+@echo dfl_options=%dfl_options%>>dflcompile.info
+@%dmd_path_windows%\bin\dmd>>dflcompile.info
+
+@rem this flag used when called from go.bat
+@set dfl_failed=
+@goto done
+:oops
+@set dfl_failed=1
+@echo.
+@echo Failed.
+
+
+:done
+@echo.
+@echo Done.
+
+
+@rem   @del %dfl_objs%
+@del *.obj
+
+pause

--- a/win32/dfl/makelib.bat
+++ b/win32/dfl/makelib.bat
@@ -4,6 +4,14 @@
 @rem   Requires DMD and DMC's libs
 @rem   Free downloads from http://www.digitalmars.com/d/dcompiler.html and http://www.digitalmars.com/download/freecompiler.html
 
+if "%1"=="64" (
+  @call makecoff.bat %1
+  goto done
+)
+if "%1"=="32mscoff" (
+  @call makecoff.bat %1
+  goto done
+)
 
 @echo off
 @cls

--- a/win32/dflexe/dflexe.d
+++ b/win32/dflexe/dflexe.d
@@ -817,6 +817,9 @@ int main(/+ string[] args +/)
 				"\r\n   @" ~ std.path.driveName(dflsrcdir)
 				~ "\r\n   @cd \"" ~ dflsrcdir ~ "\"");
 			
+            // argument %1 will be passed by the call to system() below
+			batf.writeString("\r\n   @set MODEL=%1");
+            
 			batf.writeString(
 				"\r\n   @set _old_dmd_path=%dmd_path%"
 				"\r\n   @set dmd_path=" ~ dmdpath
@@ -838,7 +841,8 @@ int main(/+ string[] args +/)
 			batf.writeString("\r\n   @set dfl_failed=-1"); // Let makelib.bat unset this.
 			
 			//batf.writeString("\r\n   @call \"" ~ std.path.buildPath(dflsrcdir, "go.bat") ~ "\"\r\n");
-			batf.writeString("\r\n   @call \"" ~ std.path.buildPath(dflsrcdir, "makelib.bat") ~ "\"\r\n");
+            // call the batch with the model parameter
+			batf.writeString("\r\n   @call \"" ~ std.path.buildPath(dflsrcdir, "makelib.bat") ~ "\" %MODEL%\r\n");
 			
 			batf.writeString("\r\n" `@if not "%dfl_failed%" == "" goto fail`); // No longer using go.bat for this.
 			
@@ -866,7 +870,13 @@ int main(/+ string[] args +/)
 				batf.writeString("\r\n   @set path=%_old_path%");
 			}
 			
-			batf.writeString("\r\n   @move /Y dfl*.lib %dmd_path_windows%\\lib > NUL"); // Important! no longer using go.bat for this.
+			batf.writeString("\r\n   @if %MODEL%==32 (");
+			batf.writeString("\r\n   @set lib_dest=lib");
+			batf.writeString("\r\n   ) else (");
+			batf.writeString("\r\n   @set lib_dest=lib%MODEL%");
+			batf.writeString("\r\n   )");
+			batf.writeString("\r\n   @move /Y dfl*.lib %dmd_path_windows%\\%lib_dest% > NUL"); // Important! no longer using go.bat for this.
+			batf.writeString("\r\n   @set lib_dest=");
 			
 			batf.writeString("\r\n:fail\r\n");
 			
@@ -887,7 +897,7 @@ int main(/+ string[] args +/)
 			
 			batf.close();
 			
-			std.process.system(batfilepath);
+            std.process.system(batfilepath ~ " " ~ model); // pass model as %1
 			
 			std.file.remove(batfilepath);
 		}

--- a/win32/dflexe/dflexe.d
+++ b/win32/dflexe/dflexe.d
@@ -71,6 +71,7 @@ bool isPrepared = false;
 bool isDebug = true;
 bool debugSpecified = false;
 string dlibname; // Read from sc.ini
+string model = "32"; // 32,64,or 32mscoff
 
 string optExet = "nt"; // Exe type.
 string optSu = "console:4.0"; // Subsystem.
@@ -667,6 +668,10 @@ int main(/+ string[] args +/)
 						break;
 					
 					default: regular_switch:
+						if (_origarg == "-m32mscoff") model = "32mscoff";
+						else if (_origarg == "-m32") model = "32"; // default
+						else if (_origarg == "-m64") model = "64";
+						
 						if(!doDflSwitch(arg))
 							dmdargs ~= quotearg(_origarg);
 				}
@@ -930,7 +935,8 @@ int main(/+ string[] args +/)
 				//dfllib = std.path.buildPath(basepath, "lib\\" ~ libfile);
 				//if(!std.file.exists(dfllib))
 				{
-					dfllib = std.path.buildPath(dmdpath_windows, "lib\\" ~ libfile);
+                    string libsubdir = model != "32" ? "lib" ~ model : "lib"; // lib64, lib32mscoff
+					dfllib = std.path.buildPath(dmdpath_windows, libsubdir ~ "\\" ~ libfile);
 					if(!std.file.exists(dfllib))
 					{
 						dfllib = null;
@@ -1184,7 +1190,8 @@ int main(/+ string[] args +/)
 					dmdargs ~= dfl_options;
 				}
 			}
-			dmdargs ~= "-L/exet:" ~ optExet ~ "/su:" ~ optSu;
+            if (model=="32") // for dmd/optlink only
+                dmdargs ~= "-L/exet:" ~ optExet ~ "/su:" ~ optSu;
 			dmdargs ~= getshortpath(dfllib);
 			
 			// Call DMD.


### PR DESCRIPTION
DMD 2.069 can make 32-bit COFF binary and have runtime libraries.
So, I fix DFL's toolchains, which are dfl.exe and makeXX.bat files.

It requires MSVC and WindowsSDK, as same as 64-bit build mode.
I tested with VS2013 Community Edition.
If one uses with another version, please modify the environment settings inside of makecoff.bat.

These changes were originally made as part of DFL64, but fully imploved.
